### PR TITLE
Fix shop homepage glide

### DIFF
--- a/assets/css/shop.css
+++ b/assets/css/shop.css
@@ -14,9 +14,11 @@
 .shop-products figcaption span {
   color: var(--color-text-grey);
 }
-.shop-products li:first-child {
-  grid-column: 2 span;
-  grid-row: 2 span;
+@media screen and (min-width: 60rem) {
+  .shop-products li:first-child {
+    grid-column: 2 span;
+    grid-row: 2 span;
+  }
 }
 .shop-product-description {
   margin-bottom: 1.5rem;


### PR DESCRIPTION
Fixed the issue on mobile with showing first item as `2 column` only wider than `60rem` screens.

Tested on Windows 10 & Chrome & Firefox

Fixes #34 