### PR TITLE
Remove `title` from `site.yml`

### DIFF
--- a/site/blueprints/site.yml
+++ b/site/blueprints/site.yml
@@ -1,4 +1,3 @@
-title: Site
 
 columns:
   - width: 1/3


### PR DESCRIPTION
To actually use `view.site` translation strings in the Panel.